### PR TITLE
Convert Events into extension functions AND Modify the way Novu class is constructed

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -48,12 +48,11 @@ then run `gradlew build`
 To use the library, first initialize the client with your API token:
 
 ```kotlin
-// without changing the backendUrl
+// without changing the backend URL
 import co.novu.Novu
 import co.novu.extentions.environments
 
-fun main() 
-{
+fun main() {
     val novu = Novu(apiKey = "API_KEY")
     val environment = novu.environments()
     println(environment)
@@ -67,8 +66,8 @@ import co.novu.NovuConfig
 import co.novu.extentions.environments
 
 fun main() {
-    val config = NovuConfig(backendUrl = "http://localhost:8080/v1/")
-    val novu = Novu(apiKey = "API_KEY",config)
+    val config = NovuConfig(backendUrl = "http://localhost:8080/v1/", apiKey = "API_KEY")
+    val novu = Novu(config)
     val environment = novu.environments()
     println(environment)
 } 
@@ -82,23 +81,23 @@ novu.subscribers()
 
 ## List of all methods
 
-The client methods map directly to the Novu API endpoints. Here's a list of all the available methods. Check [the API docs](https://docs.novu.co/api/overview) for list of available `methods`.
+The client methods map directly to the Novu API endpoints. Here is a list of all the available methods. Check [the API docs](https://docs.novu.co/api/overview) for list of available `methods`.
 
 ### Changes
 
 - `changes(query = {})`
 - `countChanges()`
 - `applyBulkChanges()`
-- `applyChange(change_id)`
+- `applyChange(changeId)`
 
 ### Environments
 
 - `currentEnvironment()`
 - `createEnvironment(body)`
 - `environments()`
-- `updateEnvironment(environment_id, body)`
+- `updateEnvironment(environmentId, body)`
 - `apiKeys()`
-- `regenerate_api_keys()`
+- `regenerateApiKeys()`
 - `updateWidgetSettings(body)`
 
 ### Events
@@ -116,7 +115,7 @@ The client methods map directly to the Novu API endpoints. Here's a list of all 
 
 - `createFeed(body)`
 - `feeds()`
-- `deleteFeed(feed_id)`
+- `deleteFeed(feedId)`
 
 ### Inbound Parse
 

--- a/src/main/kotlin/Novu.kt
+++ b/src/main/kotlin/Novu.kt
@@ -21,16 +21,20 @@ import co.novu.helpers.RetrofitHelper
 import kotlinx.coroutines.runBlocking
 import mu.KotlinLogging
 
-data class NovuConfig(var backendUrl: String? = "https://api.novu.co/v1/")
+data class NovuConfig(
+    var backendUrl: String = "https://api.novu.co/v1/",
+    var apiKey: String = ""
+)
 
 class Novu(
-    apiKey: String,
-    config: NovuConfig? = NovuConfig()
+    config: NovuConfig
 ) {
+
+    constructor(apiKey: String) : this(NovuConfig(apiKey = apiKey))
 
     private val logger = KotlinLogging.logger {}
 
-    private val retrofitInstance = RetrofitHelper(apiKey = apiKey, baseUrl = config?.backendUrl!!).getInstance()
+    private val retrofitInstance = RetrofitHelper(config).getInstance()
 
     private val eventsApi = retrofitInstance.create(EventsApi::class.java)
 

--- a/src/main/kotlin/Novu.kt
+++ b/src/main/kotlin/Novu.kt
@@ -14,12 +14,7 @@ import co.novu.api.NotificationTemplatesApi
 import co.novu.api.NotificationsApi
 import co.novu.api.SubscribersApi
 import co.novu.api.TopicsApi
-import co.novu.dto.request.BroadcastEventRequest
-import co.novu.dto.request.BulkTriggerEventRequest
-import co.novu.dto.request.TriggerEventRequest
 import co.novu.helpers.RetrofitHelper
-import kotlinx.coroutines.runBlocking
-import mu.KotlinLogging
 
 data class NovuConfig(
     var backendUrl: String = "https://api.novu.co/v1/",
@@ -32,11 +27,9 @@ class Novu(
 
     constructor(apiKey: String) : this(NovuConfig(apiKey = apiKey))
 
-    private val logger = KotlinLogging.logger {}
-
     private val retrofitInstance = RetrofitHelper(config).getInstance()
 
-    private val eventsApi = retrofitInstance.create(EventsApi::class.java)
+    internal val eventsApi = retrofitInstance.create(EventsApi::class.java)
 
     internal val subscribersApi = retrofitInstance.create(SubscribersApi::class.java)
 
@@ -63,39 +56,4 @@ class Novu(
     internal val notificationGroupsApi = retrofitInstance.create(NotificationGroupsApi::class.java)
 
     internal val inboundParseApi = retrofitInstance.create(InboundParseApi::class.java)
-    fun trigger(body: TriggerEventRequest) = runBlocking {
-        val response = eventsApi.triggerEvent(body)
-        if (response.isSuccessful) {
-            response.body().apply { logger.debug { this } }
-        } else {
-            throw Exception(response.errorBody()?.string())
-        }
-    }
-
-    fun bulkTrigger(body: BulkTriggerEventRequest) = runBlocking {
-        val response = eventsApi.bulkTriggerEvent(body)
-        if (response.isSuccessful) {
-            response.body().apply { logger.debug { this } }
-        } else {
-            throw Exception(response.errorBody()?.string())
-        }
-    }
-
-    fun broadcast(body: BroadcastEventRequest) = runBlocking {
-        val response = eventsApi.broadcastEvent(body)
-        if (response.isSuccessful) {
-            response.body().apply { logger.debug { this } }
-        } else {
-            throw Exception(response.errorBody()?.string())
-        }
-    }
-
-    fun cancelTriggerEvent(transactionId: String) = runBlocking {
-        val response = eventsApi.cancelTriggerEvent(transactionId)
-        if (response.isSuccessful) {
-            response.body().apply { logger.debug { this } }
-        } else {
-            throw Exception(response.errorBody()?.string())
-        }
-    }
 }

--- a/src/main/kotlin/extentions/EventsExtensions.kt
+++ b/src/main/kotlin/extentions/EventsExtensions.kt
@@ -1,0 +1,46 @@
+package co.novu.extensions
+
+import co.novu.Novu
+import co.novu.dto.request.BroadcastEventRequest
+import co.novu.dto.request.BulkTriggerEventRequest
+import co.novu.dto.request.TriggerEventRequest
+import kotlinx.coroutines.runBlocking
+import mu.KotlinLogging
+
+private val logger = KotlinLogging.logger {}
+
+fun Novu.trigger(body: TriggerEventRequest) = runBlocking {
+    val response = eventsApi.triggerEvent(body)
+    if (response.isSuccessful) {
+        response.body().apply { logger.debug { this } }
+    } else {
+        throw Exception(response.errorBody()?.string())
+    }
+}
+
+fun Novu.bulkTrigger(body: BulkTriggerEventRequest) = runBlocking {
+    val response = eventsApi.bulkTriggerEvent(body)
+    if (response.isSuccessful) {
+        response.body().apply { logger.debug { this } }
+    } else {
+        throw Exception(response.errorBody()?.string())
+    }
+}
+
+fun Novu.broadcast(body: BroadcastEventRequest) = runBlocking {
+    val response = eventsApi.broadcastEvent(body)
+    if (response.isSuccessful) {
+        response.body().apply { logger.debug { this } }
+    } else {
+        throw Exception(response.errorBody()?.string())
+    }
+}
+
+fun Novu.cancelTriggerEvent(transactionId: String) = runBlocking {
+    val response = eventsApi.cancelTriggerEvent(transactionId)
+    if (response.isSuccessful) {
+        response.body().apply { logger.debug { this } }
+    } else {
+        throw Exception(response.errorBody()?.string())
+    }
+}

--- a/src/main/kotlin/helpers/RetrofitHelper.kt
+++ b/src/main/kotlin/helpers/RetrofitHelper.kt
@@ -1,5 +1,6 @@
 package co.novu.helpers
 
+import co.novu.NovuConfig
 import com.google.gson.GsonBuilder
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
@@ -7,8 +8,7 @@ import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
 class RetrofitHelper(
-    private val baseUrl: String,
-    private val apiKey: String,
+    private val config: NovuConfig,
     private val loggerLevel: HttpLoggingInterceptor.Level = HttpLoggingInterceptor.Level.BASIC
 ) {
 
@@ -18,14 +18,14 @@ class RetrofitHelper(
         httpClient
             .addInterceptor { chain ->
                 val request = chain.request().newBuilder()
-                    .addHeader("Authorization", "ApiKey $apiKey")
+                    .addHeader("Authorization", "ApiKey ${config.apiKey}")
                     .build()
                 chain.proceed(request)
             }
             .addInterceptor(HttpLoggingInterceptor().setLevel(loggerLevel))
             .build()
         val gson = GsonBuilder().setLenient().create()
-        return Retrofit.Builder().client(httpClient.build()).baseUrl(baseUrl)
+        return Retrofit.Builder().client(httpClient.build()).baseUrl(config.backendUrl)
             .addConverterFactory(GsonConverterFactory.create(gson))
             .build()
     }

--- a/src/test/kotlin/ChangesApiTest.kt
+++ b/src/test/kotlin/ChangesApiTest.kt
@@ -20,8 +20,7 @@ import java.util.*
 class ChangesApiTest {
     private val mockWebServer = MockWebServer()
     private val mockNovu = Novu(
-        apiKey = "1245",
-        NovuConfig(backendUrl = mockWebServer.url("").toString())
+        NovuConfig(apiKey = "1245", backendUrl = mockWebServer.url("").toString())
     )
 
     @Test

--- a/src/test/kotlin/EnvironmentsApiTest.kt
+++ b/src/test/kotlin/EnvironmentsApiTest.kt
@@ -25,8 +25,7 @@ import org.junit.jupiter.api.Test
 class EnvironmentsApiTest {
     private val mockWebServer = MockWebServer()
     private val mockNovu = Novu(
-        apiKey = "1245",
-        NovuConfig(backendUrl = mockWebServer.url("").toString())
+        NovuConfig(apiKey = "1245", backendUrl = mockWebServer.url("").toString())
     )
 
     @Test

--- a/src/test/kotlin/EventsApiTest.kt
+++ b/src/test/kotlin/EventsApiTest.kt
@@ -19,8 +19,7 @@ import org.junit.jupiter.api.Test
 class EventsApiTest {
     private val mockWebServer = MockWebServer()
     private val mockNovu = Novu(
-        apiKey = "1245",
-        NovuConfig(backendUrl = mockWebServer.url("").toString())
+        NovuConfig(apiKey = "1245", backendUrl = mockWebServer.url("").toString())
     )
 
     @Test

--- a/src/test/kotlin/EventsApiTest.kt
+++ b/src/test/kotlin/EventsApiTest.kt
@@ -7,6 +7,10 @@ import co.novu.dto.request.SubscriberRequest
 import co.novu.dto.request.TriggerEventRequest
 import co.novu.dto.response.ResponseWrapper
 import co.novu.dto.response.TriggerResponse
+import co.novu.extensions.broadcast
+import co.novu.extensions.bulkTrigger
+import co.novu.extensions.cancelTriggerEvent
+import co.novu.extensions.trigger
 import com.google.gson.Gson
 import com.google.gson.JsonParser
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/src/test/kotlin/ExecutionDetailsApiTest.kt
+++ b/src/test/kotlin/ExecutionDetailsApiTest.kt
@@ -14,8 +14,7 @@ import org.junit.jupiter.api.Test
 class ExecutionDetailsApiTest {
     private val mockWebServer = MockWebServer()
     private val mockNovu = Novu(
-        apiKey = "1245",
-        NovuConfig(backendUrl = mockWebServer.url("").toString())
+        NovuConfig(apiKey = "1245", backendUrl = mockWebServer.url("").toString())
     )
 
     @Test

--- a/src/test/kotlin/FeedsApiTest.kt
+++ b/src/test/kotlin/FeedsApiTest.kt
@@ -17,8 +17,7 @@ import org.junit.jupiter.api.Test
 class FeedsApiTest {
     private val mockWebServer = MockWebServer()
     private val mockNovu = Novu(
-        apiKey = "1245",
-        NovuConfig(backendUrl = mockWebServer.url("").toString())
+        NovuConfig(apiKey = "1245", backendUrl = mockWebServer.url("").toString())
     )
 
     @Test

--- a/src/test/kotlin/InboundParseApiTest.kt
+++ b/src/test/kotlin/InboundParseApiTest.kt
@@ -13,8 +13,7 @@ import org.junit.jupiter.api.Test
 class InboundParseApiTest {
     private val mockWebServer = MockWebServer()
     private val mockNovu = Novu(
-        apiKey = "1245",
-        NovuConfig(backendUrl = mockWebServer.url("").toString())
+        NovuConfig(apiKey = "1245", backendUrl = mockWebServer.url("").toString())
     )
 
     @Test

--- a/src/test/kotlin/IntegrationsApiTest.kt
+++ b/src/test/kotlin/IntegrationsApiTest.kt
@@ -21,8 +21,7 @@ import org.junit.jupiter.api.Test
 class IntegrationsApiTest {
     private val mockWebServer = MockWebServer()
     private val mockNovu = Novu(
-        apiKey = "1245",
-        NovuConfig(backendUrl = mockWebServer.url("").toString())
+        NovuConfig(apiKey = "1245", backendUrl = mockWebServer.url("").toString())
     )
 
     @Test

--- a/src/test/kotlin/LayoutsApiTest.kt
+++ b/src/test/kotlin/LayoutsApiTest.kt
@@ -22,8 +22,7 @@ import java.math.BigInteger
 class LayoutsApiTest {
     private val mockWebServer = MockWebServer()
     private val mockNovu = Novu(
-        apiKey = "1245",
-        NovuConfig(backendUrl = mockWebServer.url("").toString())
+        NovuConfig(apiKey = "1245", backendUrl = mockWebServer.url("").toString())
     )
 
     @Test

--- a/src/test/kotlin/MessagesApiTest.kt
+++ b/src/test/kotlin/MessagesApiTest.kt
@@ -27,8 +27,7 @@ import java.math.BigInteger
 class MessagesApiTest {
     private val mockWebServer = MockWebServer()
     private val mockNovu = Novu(
-        apiKey = "1245",
-        NovuConfig(backendUrl = mockWebServer.url("").toString())
+        NovuConfig(apiKey = "1245", backendUrl = mockWebServer.url("").toString())
     )
 
     @Test

--- a/src/test/kotlin/NotificationGroupsApiTest.kt
+++ b/src/test/kotlin/NotificationGroupsApiTest.kt
@@ -16,8 +16,7 @@ import org.junit.jupiter.api.Test
 class NotificationGroupsApiTest {
     private val mockWebServer = MockWebServer()
     private val mockNovu = Novu(
-        apiKey = "1245",
-        NovuConfig(backendUrl = mockWebServer.url("").toString())
+        NovuConfig(apiKey = "1245", backendUrl = mockWebServer.url("").toString())
     )
 
     @Test

--- a/src/test/kotlin/NotificationTemplatesApiTest.kt
+++ b/src/test/kotlin/NotificationTemplatesApiTest.kt
@@ -30,8 +30,7 @@ import java.math.BigInteger
 class NotificationTemplatesApiTest {
     private val mockWebServer = MockWebServer()
     private val mockNovu = Novu(
-        apiKey = "1245",
-        NovuConfig(backendUrl = mockWebServer.url("").toString())
+        NovuConfig(apiKey = "1245", backendUrl = mockWebServer.url("").toString())
     )
 
     @Test

--- a/src/test/kotlin/NotificationsApiTest.kt
+++ b/src/test/kotlin/NotificationsApiTest.kt
@@ -26,8 +26,7 @@ import java.util.UUID
 class NotificationsApiTest {
     private val mockWebServer = MockWebServer()
     private val mockNovu = Novu(
-        apiKey = "1245",
-        NovuConfig(backendUrl = mockWebServer.url("").toString())
+        NovuConfig(apiKey = "1245", backendUrl = mockWebServer.url("").toString())
     )
 
     @Test

--- a/src/test/kotlin/SubscriberApiTest.kt
+++ b/src/test/kotlin/SubscriberApiTest.kt
@@ -44,8 +44,7 @@ import java.math.BigInteger
 class SubscriberApiTest {
     private val mockWebServer = MockWebServer()
     private val mockNovu = Novu(
-        apiKey = "1245",
-        NovuConfig(backendUrl = mockWebServer.url("").toString())
+        NovuConfig(apiKey = "1245", backendUrl = mockWebServer.url("").toString())
     )
 
     @Test

--- a/src/test/kotlin/TopicsApiTest.kt
+++ b/src/test/kotlin/TopicsApiTest.kt
@@ -26,8 +26,7 @@ import java.math.BigInteger
 class TopicsApiTest {
     private val mockWebServer = MockWebServer()
     private val mockNovu = Novu(
-        apiKey = "1245",
-        NovuConfig(backendUrl = mockWebServer.url("").toString())
+        NovuConfig(apiKey = "1245", backendUrl = mockWebServer.url("").toString())
     )
 
     @Test


### PR DESCRIPTION
- The 2 constructors for the Novu class are now **Novu(apiKey)** and **Novu(novuConfig)** (instead of **Novu(apiKey, novuConfig)**). That means the NovuConfig class now has apiKey as one of the fields. With this approach, we can easily introduce more parameters into the NovuConfig class in the future

- Also, for separation of concerns, the Event functions were extracted into a dedicated class